### PR TITLE
Add Slalom Build capability to the platform

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -101,6 +101,15 @@ capabilities = {
         "industry_verticals": ["Technology", "Financial Services", "Healthcare"],
         "capacity": 20,
         "consultants": ["charlotte.young@slalom.com", "henry.king@slalom.com"]
+    },
+    "Slalom Build": {
+        "description": "Product development, design thinking, and agile delivery for digital innovation",
+        "practice_area": "Technology",
+        "skill_levels": ["Emerging", "Proficient", "Advanced", "Expert"],
+        "certifications": ["Certified Product Manager", "SAFe Product Owner", "Agile Certified Practitioner", "Design Thinking Certificate"],
+        "industry_verticals": ["Consumer Products", "Fintech", "Healthtech", "Retail", "Technology"],
+        "capacity": 35,
+        "consultants": ["marcus.thompson@slalom.com", "rachel.chen@slalom.com"]
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds the missing **Slalom Build** capability to the consulting platform, resolving #6
- Includes product development, design thinking, and agile delivery expertise
- Configured with appropriate certifications (Certified Product Manager, SAFe Product Owner, Agile Certified Practitioner, Design Thinking Certificate)
- Maps to relevant industry verticals: Consumer Products, Fintech, Healthtech, Retail, Technology
- Sets initial capacity at 35 hours/week with two pre-registered consultants

## Changes
- `src/app.py`: Added "Slalom Build" entry to the in-memory capabilities dictionary

Closes #6